### PR TITLE
Try fixing application config not found ERROR -9

### DIFF
--- a/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
+++ b/src/android/src/com/nordnetab/chcp/main/HotCodePushPlugin.java
@@ -608,6 +608,8 @@ public class HotCodePushPlugin extends CordovaPlugin {
             pluginInternalPrefs.setCurrentReleaseVersionName(appConfig.getContentConfig().getReleaseVersion());
 
             pluginInternalPrefsStorage.storeInPreference(pluginInternalPrefs);
+            // https://github.com/salb3la/cordova-hot-code-push/commit/7ccb90fc1dbaa03133a9304933952ddac7298da1
+            fileStructure.switchToRelease(pluginInternalPrefs.getCurrentReleaseVersionName());
         }
 
         AssetsHelper.copyAssetDirectoryToAppDirectory(cordova.getActivity().getApplicationContext(), WWW_FOLDER, fileStructure.getWwwFolder());

--- a/src/ios/HCPPlugin.m
+++ b/src/ios/HCPPlugin.m
@@ -106,6 +106,8 @@ static NSString *const DEFAULT_STARTING_PAGE = @"index.html";
         _pluginInternalPrefs.currentReleaseVersionName = config.contentConfig.releaseVersion;
 
         [_pluginInternalPrefs saveToUserDefaults];
+        // https://github.com/salb3la/cordova-hot-code-push/commit/7ccb90fc1dbaa03133a9304933952ddac7298da1
+        _filesStructure = [[HCPFilesStructure alloc] initWithReleaseVersion:_pluginInternalPrefs.currentReleaseVersionName];
     }
 
     [HCPAssetsFolderHelper installWwwFolderToExternalStorageFolder:_filesStructure.wwwFolder];


### PR DESCRIPTION
Fixes an issue where we were getting `-9 LOCAL_VERSION_OF_APPLICATION_CONFIG_NOT_FOUND` errors when trying to hotcode. This was preventing the current unreleased Ionic WKWebview version of the app from hotcoding at all.

Changes ported from here:

https://github.com/salb3la/cordova-hot-code-push/commit/7ccb90fc1dbaa03133a9304933952ddac7298da1